### PR TITLE
Implement basic Kotlin backend

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -Dserver.port=$PORT -jar build/libs/interviewmate-0.0.1-SNAPSHOT.jar

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# interviewmate
+# InterviewMate Backend
+
+This repository contains a minimal Kotlin Spring Boot backend for InterviewMate. It exposes endpoints to generate interview questions and CVs using the OpenAI API.
+
+## Requirements
+- Java 17+
+- Gradle
+- OpenAI API key set in the `OPENAI_API_KEY` environment variable
+
+## Running locally
+```bash
+./gradlew bootRun
+```
+
+Endpoints:
+- `POST /generate-cv` – body `{ "jobName": "<role>" }`
+- `POST /generate-questions` – body `{ "jobName": "<role>", "jobDetails": "<description>" }`
+
+The server binds to port defined by `$PORT` (default `8080`). Heroku will automatically provide this variable.
+
+## Deploying to Heroku
+Build the project and push the jar with a `Procfile`.
+```
+./gradlew clean build
+```
+
+Heroku will run the jar using the command in `Procfile`.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,25 @@
+plugins {
+    id("org.springframework.boot") version "3.1.5"
+    id("io.spring.dependency-management") version "1.1.3"
+    kotlin("jvm") version "1.9.10"
+    kotlin("plugin.spring") version "1.9.10"
+}
+
+group = "com.interviewmate"
+version = "0.0.1-SNAPSHOT"
+java.sourceCompatibility = JavaVersion.VERSION_17
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.theokanning.openai-gpt3-java:service:0.18.2")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.withType<Test> {
+    useJUnitPlatform()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "interviewmate"

--- a/src/main/kotlin/com/interviewmate/Application.kt
+++ b/src/main/kotlin/com/interviewmate/Application.kt
@@ -1,0 +1,11 @@
+package com.interviewmate
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class Application
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}

--- a/src/main/kotlin/com/interviewmate/controller/InterviewController.kt
+++ b/src/main/kotlin/com/interviewmate/controller/InterviewController.kt
@@ -1,0 +1,37 @@
+package com.interviewmate.controller
+
+import com.interviewmate.service.AIService
+import com.theokanning.openai.completion.chat.ChatMessage
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+data class InterviewRequest(val jobName: String, val jobDetails: String)
+data class InterviewResponse(val questions: List<String>)
+
+data class CvRequest(val jobName: String)
+data class CvResponse(val cv: String)
+
+@RestController
+class InterviewController(private val aiService: AIService) {
+
+    @PostMapping("/generate-questions")
+    fun generateQuestions(@RequestBody request: InterviewRequest): ResponseEntity<InterviewResponse> {
+        val prompt = "Generate 10 interview questions for a position titled '${request.jobName}'. Job details: ${request.jobDetails}"
+        val messages = listOf(ChatMessage("user", prompt))
+        val result = aiService.chat(messages)
+        val text = result.choices.first().message.content
+        val questions = text.split("\n").filter { it.isNotBlank() }
+        return ResponseEntity.ok(InterviewResponse(questions))
+    }
+
+    @PostMapping("/generate-cv")
+    fun generateCv(@RequestBody request: CvRequest): ResponseEntity<CvResponse> {
+        val prompt = "Generate a professional CV for the following role: ${request.jobName}"
+        val messages = listOf(ChatMessage("user", prompt))
+        val result = aiService.chat(messages)
+        val text = result.choices.first().message.content
+        return ResponseEntity.ok(CvResponse(text))
+    }
+}

--- a/src/main/kotlin/com/interviewmate/service/OpenAIService.kt
+++ b/src/main/kotlin/com/interviewmate/service/OpenAIService.kt
@@ -1,0 +1,26 @@
+package com.interviewmate.service
+
+import com.theokanning.openai.service.OpenAiService
+import com.theokanning.openai.completion.chat.ChatCompletionRequest
+import com.theokanning.openai.completion.chat.ChatCompletionResult
+import com.theokanning.openai.completion.chat.ChatMessage
+import org.springframework.stereotype.Service
+
+@Service
+class AIService {
+    private val client: OpenAiService
+
+    init {
+        val token = System.getenv("OPENAI_API_KEY")
+            ?: throw IllegalStateException("OPENAI_API_KEY environment variable not set")
+        client = OpenAiService(token)
+    }
+
+    fun chat(messages: List<ChatMessage>): ChatCompletionResult {
+        val request = ChatCompletionRequest.builder()
+            .model("gpt-3.5-turbo")
+            .messages(messages)
+            .build()
+        return client.createChatCompletion(request)
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+server.port=${PORT:8080}


### PR DESCRIPTION
## Summary
- set up Gradle Kotlin project with Spring Boot
- add OpenAI service for ChatGPT calls
- implement controller endpoints to create CV text and interview questions
- add Procfile and docs for running on Heroku

## Testing
- `gradle -v`

------
https://chatgpt.com/codex/tasks/task_e_685c5c124ec8832aba91e1425c442172