### PR TITLE
Add database entities and repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.postgresql:postgresql:42.7.3")
     implementation("io.jsonwebtoken:jjwt-api:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")

--- a/src/main/kotlin/com/interviewmate/Application.kt
+++ b/src/main/kotlin/com/interviewmate/Application.kt
@@ -2,9 +2,19 @@ package com.interviewmate
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.boot.CommandLineRunner
+import com.interviewmate.repository.UserRepository
 
 @SpringBootApplication
-class InterviewMateApplication
+class InterviewMateApplication {
+
+    @Bean
+    fun initDatabase(userRepository: UserRepository): CommandLineRunner = CommandLineRunner {
+        val userCount = userRepository.count()
+        println("Database ready: user table rows = $userCount")
+    }
+}
 
 // Entry point for the Spring Boot application
 fun main(args: Array<String>) {

--- a/src/main/kotlin/com/interviewmate/model/InterviewSession.kt
+++ b/src/main/kotlin/com/interviewmate/model/InterviewSession.kt
@@ -1,0 +1,35 @@
+package com.interviewmate.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.Lob
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "interview_sessions")
+data class InterviewSession(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User? = null,
+
+    val jobName: String = "",
+
+    @Column(length = 4000)
+    val jobDescription: String = "",
+
+    val generatedAt: Instant = Instant.now(),
+
+    @Lob
+    val questionsJson: String = ""
+)

--- a/src/main/kotlin/com/interviewmate/model/User.kt
+++ b/src/main/kotlin/com/interviewmate/model/User.kt
@@ -1,0 +1,30 @@
+package com.interviewmate.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.validation.constraints.Email
+import java.time.Instant
+
+@Entity
+@Table(name = "users")
+data class User(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @field:Email
+    @Column(unique = true)
+    val email: String = "",
+
+    val passwordHash: String = "",
+
+    val role: String = "USER",
+
+    val subscriptionStatus: String = "NONE",
+
+    val createdAt: Instant = Instant.now()
+)

--- a/src/main/kotlin/com/interviewmate/repository/InterviewSessionRepository.kt
+++ b/src/main/kotlin/com/interviewmate/repository/InterviewSessionRepository.kt
@@ -1,0 +1,8 @@
+package com.interviewmate.repository
+
+import com.interviewmate.model.InterviewSession
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface InterviewSessionRepository : JpaRepository<InterviewSession, Long>

--- a/src/main/kotlin/com/interviewmate/repository/UserRepository.kt
+++ b/src/main/kotlin/com/interviewmate/repository/UserRepository.kt
@@ -1,0 +1,10 @@
+package com.interviewmate.repository
+
+import com.interviewmate.model.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<User, Long> {
+    fun findByEmail(email: String): User?
+}


### PR DESCRIPTION
## Summary
- configure validation starter for JPA entities
- create User and InterviewSession entity classes
- add UserRepository and InterviewSessionRepository
- log database readiness on startup

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_688a5b7fea0c832aa0fb5b4d3f812c18