### PR TITLE
Implement JWT authentication and auth endpoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,3 +15,10 @@ This project hosts a Kotlin/Spring Boot backend. All sources live under `src/mai
 ## Modules
 - Currently single module `:interviewmate`.
 - Future agents may add entities, controllers and services under `src/main/kotlin`.
+
+## Authentication
+- Users register via `POST /api/auth/register` with an email and password. The password is hashed using BCrypt and stored in the `users` table.
+- Login is handled at `POST /api/auth/login`. When credentials are valid a JWT is returned in the response body.
+- Clients must send this token in the `Authorization` header (`Bearer <token>`) for all protected endpoints.
+- Public endpoints: registration, login, `POST /api/questions` and the health check (`GET /actuator/health`). All other API URLs require a valid JWT.
+- Tokens encode the user id and subscription status and expire after the configured `jwt.expiration-ms`.

--- a/src/main/kotlin/com/interviewmate/controller/AuthController.kt
+++ b/src/main/kotlin/com/interviewmate/controller/AuthController.kt
@@ -1,0 +1,60 @@
+package com.interviewmate.controller
+
+import com.interviewmate.model.User
+import com.interviewmate.repository.UserRepository
+import com.interviewmate.security.JwtUtil
+import jakarta.validation.Valid
+import jakarta.validation.constraints.Email
+import jakarta.validation.constraints.NotBlank
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/auth")
+class AuthController(
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder,
+    private val jwtUtil: JwtUtil
+) {
+
+    data class RegisterRequest(
+        @field:Email val email: String = "",
+        @field:NotBlank val password: String = ""
+    )
+
+    data class LoginRequest(
+        @field:Email val email: String = "",
+        @field:NotBlank val password: String = ""
+    )
+
+    data class AuthResponse(val token: String, val subscriptionStatus: String)
+
+    @PostMapping("/register")
+    fun register(@Valid @RequestBody request: RegisterRequest): ResponseEntity<Any> {
+        if (userRepository.findByEmail(request.email) != null) {
+            return ResponseEntity.badRequest().body(mapOf("error" to "Email already in use"))
+        }
+        val user = User(
+            email = request.email,
+            passwordHash = passwordEncoder.encode(request.password)
+        )
+        val saved = userRepository.save(user)
+        return ResponseEntity.status(HttpStatus.CREATED).body(mapOf("id" to saved.id))
+    }
+
+    @PostMapping("/login")
+    fun login(@Valid @RequestBody request: LoginRequest): ResponseEntity<Any> {
+        val user = userRepository.findByEmail(request.email)
+            ?: return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        if (!passwordEncoder.matches(request.password, user.passwordHash)) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build()
+        }
+        val token = jwtUtil.createToken(user.id, user.subscriptionStatus)
+        return ResponseEntity.ok(AuthResponse(token, user.subscriptionStatus))
+    }
+}

--- a/src/main/kotlin/com/interviewmate/security/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/interviewmate/security/JwtAuthenticationFilter.kt
@@ -1,0 +1,35 @@
+package com.interviewmate.security
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+@Component
+class JwtAuthenticationFilter(private val jwtUtil: JwtUtil) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val header = request.getHeader(HttpHeaders.AUTHORIZATION)
+        if (header != null && header.startsWith("Bearer ")) {
+            val token = header.substring(7)
+            val claims = jwtUtil.parseToken(token)
+            if (claims != null) {
+                val auth = UsernamePasswordAuthenticationToken(
+                    claims,
+                    null,
+                    listOf(SimpleGrantedAuthority("ROLE_USER"))
+                )
+                SecurityContextHolder.getContext().authentication = auth
+            }
+        }
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/com/interviewmate/security/JwtUtil.kt
+++ b/src/main/kotlin/com/interviewmate/security/JwtUtil.kt
@@ -1,0 +1,44 @@
+package com.interviewmate.security
+
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import java.security.Key
+import java.util.Date
+
+@Component
+class JwtUtil(
+    @Value("\${jwt.secret}") secret: String,
+    @Value("\${jwt.expiration-ms}") private val expirationMs: Long
+) {
+    private val key: Key = Keys.hmacShaKeyFor(secret.toByteArray())
+
+    data class JwtClaims(val userId: Long, val subscriptionStatus: String)
+
+    fun createToken(userId: Long, subscriptionStatus: String): String {
+        val now = Date()
+        val expiry = Date(now.time + expirationMs)
+        return Jwts.builder()
+            .setSubject(userId.toString())
+            .claim("subStatus", subscriptionStatus)
+            .setIssuedAt(now)
+            .setExpiration(expiry)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact()
+    }
+
+    fun parseToken(token: String): JwtClaims? = try {
+        val body = Jwts.parser()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .body
+        val id = body.subject.toLong()
+        val status = body["subStatus"] as String
+        JwtClaims(id, status)
+    } catch (ex: Exception) {
+        null
+    }
+}

--- a/src/main/kotlin/com/interviewmate/security/SecurityConfig.kt
+++ b/src/main/kotlin/com/interviewmate/security/SecurityConfig.kt
@@ -1,0 +1,33 @@
+package com.interviewmate.security
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+
+@Configuration
+class SecurityConfig(private val jwtFilter: JwtAuthenticationFilter) {
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http.csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests {
+                it.requestMatchers("/api/auth/register", "/api/auth/login").permitAll()
+                    .requestMatchers("/api/questions").permitAll()
+                    .requestMatchers("/actuator/health").permitAll()
+                    .anyRequest().authenticated()
+            }
+            .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter::class.java)
+            .formLogin { it.disable() }
+            .httpBasic { it.disable() }
+        return http.build()
+    }
+}

--- a/src/test/kotlin/com/interviewmate/controller/AuthControllerTest.kt
+++ b/src/test/kotlin/com/interviewmate/controller/AuthControllerTest.kt
@@ -1,0 +1,96 @@
+package com.interviewmate.controller
+
+import com.interviewmate.model.User
+import com.interviewmate.repository.UserRepository
+import com.interviewmate.security.JwtAuthenticationFilter
+import com.interviewmate.security.JwtUtil
+import com.interviewmate.security.SecurityConfig
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(AuthController::class)
+@Import(SecurityConfig::class)
+class AuthControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var userRepository: UserRepository
+
+    @MockBean
+    lateinit var passwordEncoder: PasswordEncoder
+
+    @MockBean
+    lateinit var jwtUtil: JwtUtil
+
+    @MockBean
+    lateinit var jwtFilter: JwtAuthenticationFilter
+
+    @Test
+    fun `successful registration`() {
+        given(userRepository.findByEmail("new@example.com")).willReturn(null)
+        given(passwordEncoder.encode("pass")).willReturn("hash")
+        given(userRepository.save(any())).willReturn(User(id = 1, email = "new@example.com", passwordHash = "hash"))
+
+        mockMvc.perform(
+            post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"email":"new@example.com","password":"pass"}""")
+        )
+            .andExpect(status().isCreated)
+    }
+
+    @Test
+    fun `registration conflict`() {
+        given(userRepository.findByEmail("exists@example.com")).willReturn(User(id = 2, email = "exists@example.com", passwordHash = "h"))
+
+        mockMvc.perform(
+            post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"email":"exists@example.com","password":"pass"}""")
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `successful login`() {
+        val user = User(id = 3, email = "u@example.com", passwordHash = "hash")
+        given(userRepository.findByEmail("u@example.com")).willReturn(user)
+        given(passwordEncoder.matches("pass", "hash")).willReturn(true)
+        given(jwtUtil.createToken(3, user.subscriptionStatus)).willReturn("tok")
+
+        mockMvc.perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"email":"u@example.com","password":"pass"}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("tok")))
+    }
+
+    @Test
+    fun `login failure`() {
+        val user = User(id = 4, email = "u@example.com", passwordHash = "hash")
+        given(userRepository.findByEmail("u@example.com")).willReturn(user)
+        given(passwordEncoder.matches("bad", "hash")).willReturn(false)
+
+        mockMvc.perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"email":"u@example.com","password":"bad"}""")
+        )
+            .andExpect(status().isUnauthorized)
+    }
+}


### PR DESCRIPTION
## Summary
- configure Spring Security with JWT filter
- add JWT utilities and authentication filter
- implement registration and login endpoints
- document new authentication workflow
- test AuthController registration and login flows

## Testing
- `./gradlew test --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_688a5f7864f0832aba02b2c66b4fb931