### PR TITLE
Implement interview questions endpoint with paywall

### DIFF
--- a/src/main/kotlin/com/interviewmate/controller/InterviewController.kt
+++ b/src/main/kotlin/com/interviewmate/controller/InterviewController.kt
@@ -1,0 +1,57 @@
+package com.interviewmate.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.interviewmate.dto.GenerateRequest
+import com.interviewmate.dto.GenerateResponse
+import com.interviewmate.dto.QA
+import com.interviewmate.model.InterviewSession
+import com.interviewmate.repository.InterviewSessionRepository
+import com.interviewmate.repository.UserRepository
+import com.interviewmate.security.JwtUtil
+import com.interviewmate.service.LLMService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class InterviewController(
+    private val llmService: LLMService,
+    private val sessionRepository: InterviewSessionRepository,
+    private val userRepository: UserRepository,
+    private val mapper: ObjectMapper
+) {
+    @PostMapping("/api/questions")
+    fun generateQuestions(@Valid @RequestBody req: GenerateRequest): ResponseEntity<GenerateResponse> {
+        val auth = SecurityContextHolder.getContext().authentication
+        val claims = auth?.principal as? JwtUtil.JwtClaims
+        val subscribed = claims?.subscriptionStatus == "SUBSCRIBED"
+
+        val results = try {
+            llmService.generateQuestions(req.jobName, req.jobDescription, req.numQuestions)
+        } catch (ex: Exception) {
+            return ResponseEntity.status(HttpStatus.BAD_GATEWAY).build()
+        }
+
+        if (claims != null) {
+            val user = userRepository.findById(claims.userId).orElse(null)
+            if (user != null) {
+                val session = InterviewSession(
+                    user = user,
+                    jobName = req.jobName,
+                    jobDescription = req.jobDescription,
+                    questionsJson = mapper.writeValueAsString(results)
+                )
+                sessionRepository.save(session)
+            }
+        }
+
+        val limited = if (!subscribed && results.size > 3) results.subList(0, 3) else results
+        val qas = limited.map { (q, a) -> QA(q, a) }
+        val response = GenerateResponse(qas, subscribed)
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/com/interviewmate/dto/GenerateRequest.kt
+++ b/src/main/kotlin/com/interviewmate/dto/GenerateRequest.kt
@@ -1,0 +1,22 @@
+package com.interviewmate.dto
+
+import jakarta.validation.constraints.Max
+import jakarta.validation.constraints.Min
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+/**
+ * Request payload for generating interview questions.
+ */
+data class GenerateRequest(
+    @field:NotBlank
+    val jobName: String = "",
+
+    @field:NotBlank
+    @field:Size(max = 1000)
+    val jobDescription: String = "",
+
+    @field:Min(1)
+    @field:Max(10)
+    val numQuestions: Int = 5
+)

--- a/src/main/kotlin/com/interviewmate/dto/GenerateResponse.kt
+++ b/src/main/kotlin/com/interviewmate/dto/GenerateResponse.kt
@@ -1,0 +1,14 @@
+package com.interviewmate.dto
+
+/**
+ * Response payload containing generated interview questions.
+ */
+data class QA(
+    val question: String,
+    val answer: String
+)
+
+data class GenerateResponse(
+    val questions: List<QA>,
+    val subscribed: Boolean
+)

--- a/src/test/kotlin/com/interviewmate/controller/InterviewControllerTest.kt
+++ b/src/test/kotlin/com/interviewmate/controller/InterviewControllerTest.kt
@@ -1,0 +1,122 @@
+package com.interviewmate.controller
+
+import com.interviewmate.repository.InterviewSessionRepository
+import com.interviewmate.repository.UserRepository
+import com.interviewmate.security.JwtAuthenticationFilter
+import com.interviewmate.security.JwtUtil
+import com.interviewmate.security.SecurityConfig
+import com.interviewmate.service.LLMService
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.Optional
+
+@WebMvcTest(InterviewController::class)
+@Import(SecurityConfig::class)
+class InterviewControllerTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockBean
+    lateinit var llmService: LLMService
+
+    @MockBean
+    lateinit var sessionRepository: InterviewSessionRepository
+
+    @MockBean
+    lateinit var userRepository: UserRepository
+
+    @MockBean
+    lateinit var jwtFilter: JwtAuthenticationFilter
+
+    private val questions = listOf(
+        "Q1" to "A1",
+        "Q2" to "A2",
+        "Q3" to "A3",
+        "Q4" to "A4",
+        "Q5" to "A5"
+    )
+
+    @AfterEach
+    fun clearContext() {
+        SecurityContextHolder.clearContext()
+    }
+
+    @Test
+    fun `unauthenticated limited to three`() {
+        given(llmService.generateQuestions(anyString(), anyString(), anyInt())).willReturn(questions)
+
+        mockMvc.perform(
+            post("/api/questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"jobName":"Dev","jobDescription":"Desc","numQuestions":5}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.questions.length()").value(3))
+            .andExpect(jsonPath("$.subscribed").value(false))
+            .andExpect(jsonPath("$.questions[0].question").value("Q1"))
+            .andExpect(jsonPath("$.questions[2].question").value("Q3"))
+    }
+
+    @Test
+    fun `authenticated unsubscribed limited to three`() {
+        given(llmService.generateQuestions(anyString(), anyString(), anyInt())).willReturn(questions)
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty())
+
+        val claims = JwtUtil.JwtClaims(1, "NONE")
+        val auth = UsernamePasswordAuthenticationToken(claims, null, listOf())
+        SecurityContextHolder.getContext().authentication = auth
+
+        mockMvc.perform(
+            post("/api/questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"jobName":"Dev","jobDescription":"Desc","numQuestions":5}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.questions.length()").value(3))
+            .andExpect(jsonPath("$.subscribed").value(false))
+    }
+
+    @Test
+    fun `subscribed user gets full list`() {
+        given(llmService.generateQuestions(anyString(), anyString(), anyInt())).willReturn(questions)
+        given(userRepository.findById(anyLong())).willReturn(Optional.empty())
+
+        val claims = JwtUtil.JwtClaims(2, "SUBSCRIBED")
+        val auth = UsernamePasswordAuthenticationToken(claims, null, listOf())
+        SecurityContextHolder.getContext().authentication = auth
+
+        mockMvc.perform(
+            post("/api/questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"jobName":"Dev","jobDescription":"Desc","numQuestions":5}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.questions.length()").value(5))
+            .andExpect(jsonPath("$.subscribed").value(true))
+    }
+
+    @Test
+    fun `invalid input returns bad request`() {
+        mockMvc.perform(
+            post("/api/questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"jobName":"","jobDescription":"Desc"}""")
+        )
+            .andExpect(status().isBadRequest)
+    }
+}


### PR DESCRIPTION
## Summary
- add `GenerateRequest` and `GenerateResponse` DTOs
- implement `/api/questions` controller using LLM service, paywall, and session persistence
- cover free vs. subscribed access and validation with controller tests

## Testing
- `./gradlew test --rerun-tasks --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_6892574f761c832a860b63298d5cf6ae