### PR TITLE
Add tests and local development configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Copy to .env and adjust values as needed for local development.
+PORT=8080
+DATABASE_URL=jdbc:postgresql://localhost:5432/interviewdb
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+OPENAI_API_KEY=your-openai-key-here
+JWT_SECRET=your-jwt-secret-here

--- a/README.md
+++ b/README.md
@@ -1,3 +1,50 @@
 # InterviewMate
 
-This repository contains the backend service for InterviewMate built with Kotlin and Spring Boot.
+InterviewMate is a Kotlin/Spring Boot backend that generates interview questions from job
+descriptions. Users can try it without an account (first three questions free) or subscribe for
+full access and future features like CV generation.
+
+## Tech Stack
+- Kotlin & Spring Boot
+- PostgreSQL
+- OpenAI API (pluggable LLM service)
+- JWT authentication
+
+## Local Setup
+1. Start the database:
+   ```
+   docker-compose up -d db
+   ```
+2. Copy `.env.example` to `.env` and set `OPENAI_API_KEY` and `JWT_SECRET`.
+   Other values match the defaults in `application.yml`.
+3. Run the application:
+   ```
+   ./gradlew bootRun
+   ```
+   The service listens on <http://localhost:8080>.
+
+## Running Tests
+```
+./gradlew test
+```
+Tests use an in-memory H2 database.
+
+## API Usage
+- **Register** – `POST /api/auth/register` with `{ "email": "...", "password": "..." }`
+- **Login** – `POST /api/auth/login` returns `{ token, subscriptionStatus }`
+- **Generate Questions** – `POST /api/questions` with `{ "jobName": "Dev", "jobDescription": "Desc", "numQuestions": 5 }`
+  - Without a token only three questions are returned.
+  - Include `Authorization: Bearer <token>` to persist sessions and unlock the full set.
+- **Subscribe** – `POST /api/subscription/subscribe` (requires token) to mark the user as subscribed.
+
+## Deployment
+Build the runnable jar:
+```
+./gradlew build
+```
+The generated jar lives in `build/libs/`. Deployment to Heroku or other platforms will be covered in
+future tasks.
+
+## Continuous Integration
+Tests run with `./gradlew test`. TODO: add GitHub Actions and coverage badges.
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("com.h2database:h2:2.2.220")
 }
 
 java {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_DB=interviewdb
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - db_data:/var/lib/postgresql/data
+volumes:
+  db_data:

--- a/src/test/kotlin/com/interviewmate/ApplicationIntegrationTest.kt
+++ b/src/test/kotlin/com/interviewmate/ApplicationIntegrationTest.kt
@@ -1,0 +1,76 @@
+package com.interviewmate
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.interviewmate.service.LLMService
+import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.BDDMockito.given
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class ApplicationIntegrationTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var mapper: ObjectMapper
+
+    @MockBean
+    lateinit var llmService: LLMService
+
+    @Test
+    fun `full user flow`() {
+        val questions = (1..5).map { i -> "Q$i" to "A$i" }
+        given(llmService.generateQuestions(anyString(), anyString(), anyInt())).willReturn(questions)
+
+        mockMvc.perform(
+            post("/api/auth/register")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"email":"flow@example.com","password":"pass"}""")
+        ).andExpect(status().isCreated)
+
+        val loginRes = mockMvc.perform(
+            post("/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"email":"flow@example.com","password":"pass"}""")
+        ).andExpect(status().isOk)
+            .andReturn().response.contentAsString
+        val token = mapper.readTree(loginRes).get("token").asText()
+
+        mockMvc.perform(
+            post("/api/questions")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"jobName":"Dev","jobDescription":"Desc","numQuestions":5}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.questions.length()").value(3))
+            .andExpect(jsonPath("$.subscribed").value(false))
+
+        mockMvc.perform(
+            post("/api/subscription/subscribe")
+                .header("Authorization", "Bearer $token")
+        ).andExpect(status().isOk)
+
+        mockMvc.perform(
+            post("/api/questions")
+                .header("Authorization", "Bearer $token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"jobName":"Dev","jobDescription":"Desc","numQuestions":5}""")
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.questions.length()").value(5))
+            .andExpect(jsonPath("$.subscribed").value(true))
+    }
+}

--- a/src/test/kotlin/com/interviewmate/security/JwtUtilTest.kt
+++ b/src/test/kotlin/com/interviewmate/security/JwtUtilTest.kt
@@ -1,0 +1,23 @@
+package com.interviewmate.security
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+class JwtUtilTest {
+    private val util = JwtUtil("testsecret", 3600000)
+
+    @Test
+    fun `create and parse token`() {
+        val token = util.createToken(1, "SUBSCRIBED")
+        val claims = util.parseToken(token)
+        assertNotNull(claims)
+        assertEquals(1, claims!!.userId)
+        assertEquals("SUBSCRIBED", claims.subscriptionStatus)
+    }
+
+    @Test
+    fun `invalid token returns null`() {
+        val claims = util.parseToken("bad.token.here")
+        assertNull(claims)
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+    driverClassName: org.h2.Driver
+    username: sa
+    password: password
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect
+openai:
+  api-key: test
+jwt:
+  secret: testsecret
+  expiration-ms: 3600000


### PR DESCRIPTION
## Summary
- configure H2 for tests and add JWT and integration tests
- provide Docker Compose and environment example for local setup
- expand README with setup instructions and API usage

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_689268b6a360832aac95382012a8395c