### PR TITLE
Add Heroku deployment config and health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,30 @@ Tests use an in-memory H2 database.
 - **Subscribe** – `POST /api/subscription/subscribe` (requires token) to mark the user as subscribed.
 
 ## Deployment
-Build the runnable jar:
-```
-./gradlew build
-```
-The generated jar lives in `build/libs/`. Deployment to Heroku or other platforms will be covered in
-future tasks.
+### Deploying to Heroku
+1. Create an app and database:
+   ```
+   heroku create <app-name>
+   heroku addons:create heroku-postgresql:hobby-dev
+   ```
+2. Configure required secrets:
+   ```
+   heroku config:set OPENAI_API_KEY=<your_key>
+   heroku config:set JWT_SECRET=<jwt_secret>
+   ```
+   The Postgres add-on sets `DATABASE_URL` automatically.
+3. Deploy:
+   ```
+   git push heroku main
+   ```
+   The included `Procfile` and Gradle `stage` task build `interviewmate.jar`.
+4. Verify:
+   ```
+   heroku logs --tail
+   heroku open /actuator/health
+   ```
+This hobby deployment runs a single dyno and is not intended for heavy load. Ensure secrets are kept
+out of version control and adjust CORS and other production settings as needed.
 
 ## Continuous Integration
 Tests run with `./gradlew test`. TODO: add GitHub Actions and coverage badges.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,9 @@ plugins {
     kotlin("plugin.jpa") version "1.9.23"
 }
 
+group = "com.interviewmate"
+version = "0.1.0"
+
 repositories {
     mavenCentral()
 }
@@ -15,6 +18,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.postgresql:postgresql:42.7.3")
@@ -45,6 +49,10 @@ tasks.getByName<org.springframework.boot.gradle.tasks.bundling.BootJar>("bootJar
 
 tasks.getByName<org.springframework.boot.gradle.tasks.run.BootRun>("bootRun") {
     mainClass.set("com.interviewmate.ApplicationKt")
+}
+
+tasks.register("stage") {
+    dependsOn("bootJar")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/com/interviewmate/Application.kt
+++ b/src/main/kotlin/com/interviewmate/Application.kt
@@ -5,6 +5,7 @@ import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.boot.CommandLineRunner
 import com.interviewmate.repository.UserRepository
+import com.interviewmate.util.DatabaseUrlParser
 
 @SpringBootApplication
 class InterviewMateApplication {
@@ -18,7 +19,10 @@ class InterviewMateApplication {
 
 // Entry point for the Spring Boot application
 fun main(args: Array<String>) {
+    val dbUrl = System.getenv("DATABASE_URL") ?: ""
+    if (dbUrl.startsWith("postgres://")) {
+        val jdbcUrl = DatabaseUrlParser.toJdbcUrl(dbUrl)
+        System.setProperty("spring.datasource.url", jdbcUrl)
+    }
     runApplication<InterviewMateApplication>(*args)
 }
-
-// TODO Add controllers and services in future tasks

--- a/src/main/kotlin/com/interviewmate/util/DatabaseUrlParser.kt
+++ b/src/main/kotlin/com/interviewmate/util/DatabaseUrlParser.kt
@@ -1,0 +1,17 @@
+package com.interviewmate.util
+
+import java.net.URI
+
+object DatabaseUrlParser {
+    fun toJdbcUrl(url: String): String {
+        return if (url.startsWith("postgres://")) {
+            val uri = URI(url)
+            val userInfo = uri.userInfo?.split(":") ?: throw IllegalArgumentException("Invalid DATABASE_URL")
+            val user = userInfo[0]
+            val pass = userInfo[1]
+            "jdbc:postgresql://${uri.host}:${uri.port}${uri.path}?user=$user&password=$pass&sslmode=require"
+        } else {
+            url
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,8 @@ openai:
 jwt:
   secret: ${JWT_SECRET:change_me}
   expiration-ms: 3600000
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health"


### PR DESCRIPTION
## Summary
- Support Heroku by adding a `stage` Gradle task and enabling the Spring Boot Actuator for health checks
- Parse Heroku `DATABASE_URL` to JDBC format during startup
- Document Heroku deployment steps and required environment variables

## Testing
- `./gradlew build`
- `./gradlew stage`


------
https://chatgpt.com/codex/tasks/task_e_6896206dc530832a89d044db72e59eed