### PR TITLE
Support suspend LLM question generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.5")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.5")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")

--- a/src/main/kotlin/com/interviewmate/controller/InterviewController.kt
+++ b/src/main/kotlin/com/interviewmate/controller/InterviewController.kt
@@ -16,6 +16,8 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @RestController
 class InterviewController(
@@ -25,12 +27,14 @@ class InterviewController(
     private val mapper: ObjectMapper
 ) {
     @PostMapping("/api/questions")
-    fun generateQuestions(@Valid @RequestBody req: GenerateRequest): ResponseEntity<GenerateResponse> {
+    suspend fun generateQuestions(@Valid @RequestBody req: GenerateRequest): ResponseEntity<GenerateResponse> {
         val auth = SecurityContextHolder.getContext().authentication
         val claims = auth?.principal as? JwtUtil.JwtClaims
 
         val results = try {
-            llmService.generateQuestions(req.jobName, req.jobDescription, req.numQuestions)
+            withContext(Dispatchers.Default) {
+                llmService.generateQuestions(req.jobName, req.jobDescription, req.numQuestions)
+            }
         } catch (ex: Exception) {
             return ResponseEntity.status(HttpStatus.BAD_GATEWAY).build()
         }

--- a/src/main/kotlin/com/interviewmate/service/LLMService.kt
+++ b/src/main/kotlin/com/interviewmate/service/LLMService.kt
@@ -15,7 +15,7 @@ package com.interviewmate.service
  * qualifiers.
  */
 interface LLMService {
-    fun generateQuestions(
+    suspend fun generateQuestions(
         jobName: String,
         jobDescription: String,
         numQuestions: Int = 5

--- a/src/main/kotlin/com/interviewmate/service/OpenAiService.kt
+++ b/src/main/kotlin/com/interviewmate/service/OpenAiService.kt
@@ -6,6 +6,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
 
 /**
  * LLMService implementation using OpenAI's Chat Completion API.
@@ -21,7 +22,7 @@ class OpenAiService(
         .defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer $openAiApiKey")
         .build()
 
-    override fun generateQuestions(
+    override suspend fun generateQuestions(
         jobName: String,
         jobDescription: String,
         numQuestions: Int
@@ -47,8 +48,7 @@ class OpenAiService(
                 .contentType(MediaType.APPLICATION_JSON)
                 .bodyValue(request)
                 .retrieve()
-                .bodyToMono(OpenAiResponse::class.java)
-                .block() ?: throw IllegalStateException("Empty OpenAI response")
+                .awaitBody<OpenAiResponse>()
         } catch (ex: Exception) {
             throw IllegalStateException("Failed to call OpenAI", ex)
         }

--- a/src/test/kotlin/com/interviewmate/service/OpenAiServiceTest.kt
+++ b/src/test/kotlin/com/interviewmate/service/OpenAiServiceTest.kt
@@ -11,6 +11,7 @@ import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.ExchangeFunction
 import org.springframework.web.reactive.function.client.WebClient
 import reactor.core.publisher.Mono
+import kotlinx.coroutines.runBlocking
 
 class OpenAiServiceTest {
     private fun buildService(body: String): OpenAiService {
@@ -37,7 +38,7 @@ class OpenAiServiceTest {
         )
         val service = buildService(body)
 
-        val result = service.generateQuestions("dev", "desc", 1)
+        val result = runBlocking { service.generateQuestions("dev", "desc", 1) }
         assertEquals(listOf("Q1" to "A1"), result)
     }
 
@@ -47,7 +48,7 @@ class OpenAiServiceTest {
         val service = buildService(body)
 
         assertThrows(IllegalStateException::class.java) {
-            service.generateQuestions("dev", "desc", 1)
+            runBlocking { service.generateQuestions("dev", "desc", 1) }
         }
     }
 }


### PR DESCRIPTION
## Summary
- make LLMService.generateQuestions suspend and adopt coroutine-friendly awaitBody
- expose `/api/questions` as a suspend endpoint running on the default dispatcher
- adapt tests to runBlocking and async dispatch for coroutine support

## Testing
- `./gradlew test --rerun-tasks`


------
https://chatgpt.com/codex/tasks/task_e_689650c3a5bc832abc72fbbf8a34a36d